### PR TITLE
Adding support for running pillager as a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.16-alpine AS build
+
+WORKDIR /src/
+COPY . /src/
+RUN CGO_ENABLED=0 go build -o /bin/pillager
+
+FROM scratch as prod
+
+LABEL author="Britton Hayes"
+LABEL github="https://github.com/brittonhayes/pillager"
+
+COPY --from=build /bin/pillager /bin/pillager
+ENTRYPOINT ["/bin/pillager"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ brew tap brittonhayes/homebrew-pillager
 brew install pillager
 ```
 
+### Docker Image
+
+```
+docker run --rm -it bjhayes/pillager hunt . 
+```
+
 If you're looking for a binary, check the latest releases for the executable that matches your system
 
 ## Usage


### PR DESCRIPTION
# Changes

- Adds support for running pillager as a docker image
- Updates README.md instructions to include new docker run﻿
