### PR TITLE
ecshreve: some simple cleanup

### DIFF
--- a/_examples/hunter/main.go
+++ b/_examples/hunter/main.go
@@ -28,8 +28,7 @@ func main() {
 	}
 
 	// Report results
-	err = h.Report(os.Stdout, results)
-	if err != nil {
+	if err = h.Report(os.Stdout, results); err != nil {
 		log.Fatal().Err(err).Send()
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-// pillager is a tool for hunting through filesystems for sensitive information.
+// Package pillager is a tool for hunting through filesystems for sensitive information.
 //
 // Installation
 //

--- a/internal/commands/hunt.go
+++ b/internal/commands/hunt.go
@@ -72,8 +72,7 @@ var huntCmd = &cobra.Command{
 			return err
 		}
 
-		err = h.Report(os.Stdout, results)
-		if err != nil {
+		if err = h.Report(os.Stdout, results); err != nil {
 			return err
 		}
 

--- a/internal/commands/hunt.go
+++ b/internal/commands/hunt.go
@@ -1,6 +1,6 @@
-// Package commands contains the command line logic
+// Package commands contains the command line logic.
 //
-// The commands package is the primary consumer of all packages in the /pkg directory
+// The commands package is the primary consumer of all packages in the /pkg directory.
 package commands
 
 import (

--- a/internal/validate/path.go
+++ b/internal/validate/path.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Path checks if a filepath exists and
-// returns it if so, otherwise returns a default path.
+// Path checks if a file at the given path exists and returns it if so,
+// otherwise returns a default path.
 func Path(fs afero.Fs, path string) string {
 	ok, err := afero.Exists(fs, path)
 	if err != nil {

--- a/pkg/format/README.md
+++ b/pkg/format/README.md
@@ -77,13 +77,13 @@ type HTMLTable struct{}
 func (h HTMLTable) Report(w io.Writer, findings []report.Finding) error
 ```
 
-## type [JSON](<https://github.com/brittonhayes/pillager/blob/main/pkg/format/report.go#L18>)
+## type [JSON](<https://github.com/brittonhayes/pillager/blob/main/pkg/format/report.go#L19>)
 
 ```go
 type JSON struct{}
 ```
 
-### func \(JSON\) [Report](<https://github.com/brittonhayes/pillager/blob/main/pkg/format/report.go#L20>)
+### func \(JSON\) [Report](<https://github.com/brittonhayes/pillager/blob/main/pkg/format/report.go#L21>)
 
 ```go
 func (j JSON) Report(w io.Writer, findings []report.Finding) error
@@ -101,7 +101,9 @@ type Markdown struct{}
 func (m Markdown) Report(w io.Writer, findings []report.Finding) error
 ```
 
-## type [Reporter](<https://github.com/brittonhayes/pillager/blob/main/pkg/format/report.go#L14-L16>)
+## type [Reporter](<https://github.com/brittonhayes/pillager/blob/main/pkg/format/report.go#L15-L17>)
+
+Reporter is the interface that each of the canonical output formats implement\.
 
 ```go
 type Reporter interface {

--- a/pkg/format/report.go
+++ b/pkg/format/report.go
@@ -19,8 +19,7 @@ type JSON struct{}
 
 func (j JSON) Report(w io.Writer, findings []report.Finding) error {
 	encoder := json.NewEncoder(w)
-	err := encoder.Encode(&findings)
-	if err != nil {
+	if err := encoder.Encode(&findings); err != nil {
 		return err
 	}
 

--- a/pkg/format/report.go
+++ b/pkg/format/report.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Reporter is the interface that each of the canonical output formats implement.
 type Reporter interface {
 	Report(io.Writer, []report.Finding) error
 }

--- a/pkg/hunter/README.md
+++ b/pkg/hunter/README.md
@@ -6,7 +6,7 @@
 import "github.com/brittonhayes/pillager/pkg/hunter"
 ```
 
-Package hunter contains secret hunting and file scanning tools
+Package hunter contains secret hunting and file scanning tools\.
 
 ## Index
 
@@ -28,7 +28,7 @@ Package hunter contains secret hunting and file scanning tools
   - [func (h *Hunter) Report(w io.Writer, findings []report.Finding) error](<#func-hunter-report>)
 
 
-## type [Config](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L22-L33>)
+## type [Config](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L21-L32>)
 
 Config takes all of the configurable parameters for a Hunter\.
 
@@ -47,67 +47,71 @@ type Config struct {
 }
 ```
 
-### func [NewConfig](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L37>)
+### func [NewConfig](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L38>)
 
 ```go
 func NewConfig(opts ...ConfigOption) *Config
 ```
 
+NewConfig creates a Config instance\.
+
 ## type [ConfigOption](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L35>)
+
+ConfigOption is a convenient type alias for func\(\*Config\)\.
 
 ```go
 type ConfigOption func(*Config)
 ```
 
-### func [WithFS](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L72>)
+### func [WithFS](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L73>)
 
 ```go
 func WithFS(fs afero.Fs) ConfigOption
 ```
 
-### func [WithFormat](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L112>)
+### func [WithFormat](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L113>)
 
 ```go
 func WithFormat(reporter format.Reporter) ConfigOption
 ```
 
-### func [WithGitleaksConfig](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L132>)
+### func [WithGitleaksConfig](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L133>)
 
 ```go
 func WithGitleaksConfig(g config.Config) ConfigOption
 ```
 
-### func [WithLogLevel](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L84>)
+### func [WithLogLevel](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L85>)
 
 ```go
 func WithLogLevel(level string) ConfigOption
 ```
 
-### func [WithRedact](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L106>)
+### func [WithRedact](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L107>)
 
 ```go
 func WithRedact(redact bool) ConfigOption
 ```
 
-### func [WithScanPath](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L78>)
+### func [WithScanPath](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L79>)
 
 ```go
 func WithScanPath(path string) ConfigOption
 ```
 
-### func [WithTemplate](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L125>)
+### func [WithTemplate](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L126>)
 
 ```go
 func WithTemplate(template string) ConfigOption
 ```
 
-### func [WithVerbose](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L94>)
+### func [WithVerbose](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L95>)
 
 ```go
 func WithVerbose(verbose bool) ConfigOption
 ```
 
-### func [WithWorkers](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L100>)
+### func [WithWorkers](<https://github.com/brittonhayes/pillager/blob/main/pkg/hunter/config.go#L101>)
 
 ```go
 func WithWorkers(count int) ConfigOption

--- a/pkg/hunter/config.go
+++ b/pkg/hunter/config.go
@@ -17,8 +17,7 @@ import (
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
-// Config takes all of the configurable
-// parameters for a Hunter.
+// Config takes all of the configurable parameters for a Hunter.
 type Config struct {
 	Filesystem afero.Fs
 	Reporter   format.Reporter
@@ -32,8 +31,10 @@ type Config struct {
 	Template string
 }
 
+// ConfigOption is a convenient type alias for func(*Config).
 type ConfigOption func(*Config)
 
+// NewConfig creates a Config instance.
 func NewConfig(opts ...ConfigOption) *Config {
 	var (
 		defaultFS       = afero.NewOsFs()

--- a/pkg/hunter/docs.go
+++ b/pkg/hunter/docs.go
@@ -1,2 +1,2 @@
-// Package hunter contains secret hunting and file scanning tools
+// Package hunter contains secret hunting and file scanning tools.
 package hunter

--- a/pkg/rules/README.md
+++ b/pkg/rules/README.md
@@ -6,7 +6,7 @@
 import "github.com/brittonhayes/pillager/pkg/rules"
 ```
 
-Package rules enables the parsing of Gitleaks rulesets
+Package rules enables the parsing of Gitleaks rulesets\.
 
 ## Index
 
@@ -22,13 +22,15 @@ Package rules enables the parsing of Gitleaks rulesets
 
 ## Constants
 
+ErrReadConfig is the custom error message used if an error is encountered reading the gitleaks config\.
+
 ```go
-const (
-    ErrReadConfig = "Failed to read config"
-)
+const ErrReadConfig = "Failed to read gitleaks config"
 ```
 
 ## Variables
+
+These strings contain default configs\. They are initialized at compile time via go:embed\.
 
 ```go
 var (
@@ -40,7 +42,9 @@ var (
 )
 ```
 
-## type [Loader](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L25-L27>)
+## type [Loader](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L27-L29>)
+
+Loader represents a gitleaks config loader\.
 
 ```go
 type Loader struct {
@@ -48,13 +52,13 @@ type Loader struct {
 }
 ```
 
-### func [NewLoader](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L33>)
+### func [NewLoader](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L35>)
 
 ```go
 func NewLoader(opts ...LoaderOption) *Loader
 ```
 
-NewLoader creates a configuration loader\.
+NewLoader creates a Loader instance\.
 
 ### func \(\*Loader\) [Load](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L58>)
 
@@ -64,7 +68,7 @@ func (l *Loader) Load() config.Config
 
 Load parses the gitleaks configuration\.
 
-### func \(\*Loader\) [WithStrict](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L48>)
+### func \(\*Loader\) [WithStrict](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L49>)
 
 ```go
 func (l *Loader) WithStrict() LoaderOption
@@ -72,19 +76,21 @@ func (l *Loader) WithStrict() LoaderOption
 
 WithStrict enables more strict pillager scanning\.
 
-## type [LoaderOption](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L29>)
+## type [LoaderOption](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L32>)
+
+LoaderOption sets a parameter for the gitleaks config loader\.
 
 ```go
 type LoaderOption func(*Loader)
 ```
 
-### func [FromFile](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L69>)
+### func [FromFile](<https://github.com/brittonhayes/pillager/blob/main/pkg/rules/rules.go#L68>)
 
 ```go
 func FromFile(file string) LoaderOption
 ```
 
-FromFile decodes the configuration from a local file\.
+FromFile decodes a gitleaks config from a local file\.
 
 
 

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -32,8 +32,7 @@ type LoaderOption func(*Loader)
 // loader.
 func NewLoader(opts ...LoaderOption) *Loader {
 	var loader Loader
-	_, err := toml.Decode(RulesDefault, &loader.loader)
-	if err != nil {
+	if _, err := toml.Decode(RulesDefault, &loader.loader); err != nil {
 		log.Fatal().Err(err).Msg(ErrReadConfig)
 	}
 
@@ -47,8 +46,7 @@ func NewLoader(opts ...LoaderOption) *Loader {
 // WithStrict enables more strict pillager scanning.
 func (l *Loader) WithStrict() LoaderOption {
 	return func(l *Loader) {
-		_, err := toml.Decode(RulesStrict, &l.loader)
-		if err != nil {
+		if _, err := toml.Decode(RulesStrict, &l.loader); err != nil {
 			log.Fatal().Err(err).Msg(ErrReadConfig)
 		}
 	}
@@ -68,8 +66,7 @@ func (l *Loader) Load() config.Config {
 // from a local file.
 func FromFile(file string) LoaderOption {
 	return func(l *Loader) {
-		_, err := toml.DecodeFile(file, &l.loader)
-		if err != nil {
+		if _, err := toml.DecodeFile(file, &l.loader); err != nil {
 			log.Fatal().Err(err).Msg(ErrReadConfig)
 		}
 	}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,4 +1,4 @@
-// Package rules enables the parsing of Gitleaks rulesets
+// Package rules enables the parsing of Gitleaks rulesets.
 package rules
 
 import (
@@ -10,10 +10,11 @@ import (
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
-const (
-	ErrReadConfig = "Failed to read config"
-)
+// ErrReadConfig is the custom error message used if an error is encountered
+// reading the gitleaks config.
+const ErrReadConfig = "Failed to read gitleaks config"
 
+// These strings contain default configs. They are initialized at compile time via go:embed.
 var (
 	//go:embed rules_simple.toml
 	RulesDefault string
@@ -22,14 +23,15 @@ var (
 	RulesStrict string
 )
 
+// Loader represents a gitleaks config loader.
 type Loader struct {
 	loader config.ViperConfig
 }
 
+// LoaderOption sets a parameter for the gitleaks config loader.
 type LoaderOption func(*Loader)
 
-// NewLoader creates a configuration
-// loader.
+// NewLoader creates a Loader instance.
 func NewLoader(opts ...LoaderOption) *Loader {
 	var loader Loader
 	if _, err := toml.Decode(RulesDefault, &loader.loader); err != nil {
@@ -62,8 +64,7 @@ func (l *Loader) Load() config.Config {
 	return config
 }
 
-// FromFile decodes the configuration
-// from a local file.
+// FromFile decodes a gitleaks config from a local file.
 func FromFile(file string) LoaderOption {
 	return func(l *Loader) {
 		if _, err := toml.DecodeFile(file, &l.loader); err != nil {

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -1,4 +1,4 @@
-// Package templates contains a compilation of go templates for rendering secret findings
+// Package templates contains a compilation of go templates for rendering secret findings.
 package templates
 
 import (
@@ -29,8 +29,8 @@ var (
 	HTMLTable string
 )
 
-// DefaultTemplate is the base template used to
-// format a Finding into the custom output format.
+// DefaultTemplate is the base template used to format a Finding into the
+// custom output format.
 const DefaultTemplate = `{{ with . -}}
 {{ range . -}}
 Line: 	{{ quote .StartLine}}
@@ -39,8 +39,7 @@ Secret: {{ quote .Secret }}
 ---
 {{ end -}}{{- end}}`
 
-// Render renders a finding in a
-// custom go template format to the provided writer.
+// Render renders a finding in a custom go template format to the provided writer.
 func Render(w io.Writer, tpl string, findings []report.Finding) error {
 	t := template.New("custom")
 	if tpl == "" {


### PR DESCRIPTION
This PR does some basic cleanup.
- change some of the error checks to be inline `if err := someFunc(); err != nil {`
- tweak some comments for readability and godoc conventions
- regenerate docs

This should be a no-op, but I did sanity check by running locally.