### PR TITLE
feat: csv output, minimum entropy, deduplicated findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,7 @@ in with a rules[^1] section in your pillager.toml file, or you can use the defau
 # pillager.toml
 # Basic configuration
 verbose = false 
-path = "."
-workers = 4
 redact = false 
-reporter = "json-pretty"
 
 # Rules for secret detection
 [[rules]]
@@ -183,10 +180,10 @@ pillager hunt . -f html > results.html
 pillager hunt . -f markdown > results.md
 ```
 
-#### Markdown Table
+#### CSV 
 
 ```shell
-pillager hunt . -f table > results.md
+pillager hunt . -f csv > results.csv
 ```
 
 #### Custom Go Template

--- a/internal/commands/hunt.go
+++ b/internal/commands/hunt.go
@@ -34,27 +34,18 @@ var huntCmd = &cobra.Command{
 	Example: `
 	Basic:
 		pillager hunt .
-	
-	JSON Format:
-		pillager hunt ./example -f json
-	
-	YAML Format:
-		pillager hunt . -f yaml
+		
+	Wordlist Format:
+		pillager hunt . -f wordlist > results.txt
+
+	CSV Format:
+		pillager hunt . -f csv > results.csv
 	
 	HTML Format:
 		pillager hunt . -f html > results.html
-	
-	HTML Table Format:
-		pillager hunt . -f html-table > results.html
-	
-	Markdown Table Format:
-		pillager hunt . -f table > results.md
-	
+
 	Custom Go Template Format:
 		pillager hunt . --template "{{ range .}}Secret: {{.Secret}}{{end}}"
-	
-	Custom Go Template Format from Template File:
-		pillager hunt ./example --template "$(cat pkg/templates/simple.tmpl)"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts, err := setupConfig()
@@ -110,7 +101,7 @@ func init() {
 	huntCmd.Flags().StringVarP(&templ, "template", "t", "", "set go text/template string for output format")
 	huntCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "run in interactive mode")
 	huntCmd.Flags().BoolVarP(&dedupe, "dedupe", "d", false, "deduplicate results")
-	huntCmd.Flags().Float64VarP(&entropy, "entropy", "e", 4.0, "minimum entropy value for results")
+	huntCmd.Flags().Float64VarP(&entropy, "entropy", "e", 3.0, "minimum entropy value for results")
 	huntCmd.Flags().IntVarP(&workers, "workers", "w", runtime.NumCPU(), "number of concurrent workers")
 
 	// Bind flags to viper

--- a/internal/commands/hunt.go
+++ b/internal/commands/hunt.go
@@ -8,24 +8,22 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/brittonhayes/pillager"
 	"github.com/brittonhayes/pillager/pkg/scanner"
 	"github.com/brittonhayes/pillager/pkg/tui/model"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
-	verbose     bool
+	dedupe      bool
+	entropy     float64
+	format      string
 	redact      bool
-	level       string
-	reporter    string
 	templ       string
-	workers     int
 	interactive bool
-	config      string
+	workers     int
 )
 
 // huntCmd represents the hunt command.
@@ -59,45 +57,15 @@ var huntCmd = &cobra.Command{
 		pillager hunt ./example --template "$(cat pkg/templates/simple.tmpl)"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if level != "" {
-			lvl, err := zerolog.ParseLevel(level)
-			if err != nil {
-				return fmt.Errorf("invalid log level: %w", err)
-			}
-			zerolog.SetGlobalLevel(lvl)
-		}
-
-		configLoader := scanner.NewConfigLoader()
-		opts, err := configLoader.LoadConfig(config)
+		opts, err := setupConfig()
 		if err != nil {
-			if config != "" {
-				return fmt.Errorf("failed to load config: %w", err)
-			}
-			opts = &pillager.Options{
-				Workers:  runtime.NumCPU(),
-				Verbose:  false,
-				Template: "",
-				Redact:   false,
-				Reporter: "json",
-			}
+			return err
 		}
 
-		// Get path from args if provided, otherwise use config path
-		scanPath := ""
+		// Get path from args if provided
 		if len(args) > 0 {
-			scanPath = args[0]
+			opts.Path = args[0]
 		}
-
-		// Merge command line flags with config file
-		flagOpts := &pillager.Options{
-			Path:     scanPath,
-			Redact:   redact,
-			Verbose:  verbose,
-			Workers:  workers,
-			Reporter: reporter,
-			Template: templ,
-		}
-		configLoader.MergeWithFlags(opts, flagOpts)
 
 		// Check if path is provided either via args or config
 		if opts.Path == "" {
@@ -136,12 +104,20 @@ func runInteractive(h scanner.Scanner) error {
 
 func init() {
 	rootCmd.AddCommand(huntCmd)
-	huntCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "run in interactive mode")
-	huntCmd.Flags().IntVarP(&workers, "workers", "w", runtime.NumCPU(), "number of concurrent workers")
-	huntCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable scanner verbose output")
-	huntCmd.Flags().StringVarP(&level, "log-level", "l", "info", "set logging level")
-	huntCmd.Flags().StringVarP(&config, "config", "c", "", "path to pillager config file")
-	huntCmd.Flags().StringVarP(&reporter, "format", "f", "json-pretty", "set secret reporter format (json, yaml, html, html-table, table, markdown)")
+
+	huntCmd.Flags().StringVarP(&format, "format", "f", "json", "set secret reporter format")
 	huntCmd.Flags().BoolVar(&redact, "redact", false, "redact secret from results")
 	huntCmd.Flags().StringVarP(&templ, "template", "t", "", "set go text/template string for output format")
+	huntCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "run in interactive mode")
+	huntCmd.Flags().BoolVarP(&dedupe, "dedupe", "d", false, "deduplicate results")
+	huntCmd.Flags().Float64VarP(&entropy, "entropy", "e", 4.0, "minimum entropy value for results")
+	huntCmd.Flags().IntVarP(&workers, "workers", "w", runtime.NumCPU(), "number of concurrent workers")
+
+	// Bind flags to viper
+	viper.BindPFlag("dedupe", huntCmd.Flags().Lookup("dedupe"))
+	viper.BindPFlag("entropy", huntCmd.Flags().Lookup("entropy"))
+	viper.BindPFlag("format", huntCmd.Flags().Lookup("format"))
+	viper.BindPFlag("redact", huntCmd.Flags().Lookup("redact"))
+	viper.BindPFlag("template", huntCmd.Flags().Lookup("template"))
+	viper.BindPFlag("workers", huntCmd.Flags().Lookup("workers"))
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,9 +1,13 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/brittonhayes/pillager"
+	"github.com/brittonhayes/pillager/pkg/scanner"
 	"github.com/gookit/color"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog"
@@ -13,6 +17,11 @@ import (
 )
 
 var cfgFile string
+var (
+	verbose  bool
+	level    string
+	settings bool
+)
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -45,7 +54,16 @@ func Execute() {
 func init() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	cobra.OnInitialize(initConfig)
+
+	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pillager.toml)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable scanner verbose output")
+	rootCmd.PersistentFlags().StringVarP(&level, "log-level", "l", "info", "set logging level")
+	rootCmd.PersistentFlags().BoolVarP(&settings, "settings", "s", false, "print pillager settings")
+
+	// Bind flags to viper
+	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	viper.BindPFlag("log_level", rootCmd.PersistentFlags().Lookup("log-level"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -61,16 +79,67 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// Search config in home directory with name ".pillager" (without extension).
+		// Search config in multiple locations
+		viper.SetConfigName("pillager")
+		viper.AddConfigPath(".")
 		viper.AddConfigPath(home)
+		viper.AddConfigPath(filepath.Join(home, ".pillager"))
+		viper.AddConfigPath(filepath.Join(home, ".config", "pillager"))
 		viper.SetConfigType("toml")
-		viper.SetConfigName(".pillager")
 	}
 
-	viper.AutomaticEnv() // read in environment variables that match
+	// Read environment variables
+	viper.SetEnvPrefix("PILLAGER")
+	viper.AutomaticEnv()
 
-	// If a config file is found, read it in.
+	// Read config file
 	if err := viper.ReadInConfig(); err == nil {
-		log.Info().Msgf("Using config file: %q", viper.ConfigFileUsed())
+		log.Debug().Msgf("Using config file: %q", viper.ConfigFileUsed())
 	}
+
+	// Set log level
+	if level := viper.GetString("log_level"); level != "" {
+		lvl, err := zerolog.ParseLevel(level)
+		if err != nil {
+			log.Error().Err(err).Msg("invalid log level")
+		} else {
+			zerolog.SetGlobalLevel(lvl)
+		}
+	}
+
+	if viper.ConfigFileUsed() == "" {
+		log.Debug().Msg("no config file found, using defaults")
+		opts, err := scanner.ConvertDefaultConfig()
+		if err != nil {
+			log.Error().Err(err).Msg("failed to convert default config")
+		}
+
+		viper.MergeConfigMap(map[string]interface{}{
+			"verbose":   opts.Verbose,
+			"path":      opts.Path,
+			"template":  opts.Template,
+			"workers":   opts.Workers,
+			"redact":    opts.Redact,
+			"format":    opts.Format,
+			"dedupe":    opts.Dedup,
+			"entropy":   opts.Entropy,
+			"rules":     opts.Rules,
+			"allowlist": opts.Allowlist,
+		})
+	}
+
+	if settings {
+		unmarshaled, err := json.Marshal(viper.AllSettings())
+		if err != nil {
+			log.Error().Err(err).Msg("failed to marshal default config")
+		}
+
+		fmt.Println(string(unmarshaled))
+		os.Exit(0)
+	}
+}
+
+// setupConfig returns a configured Options struct
+func setupConfig() (*pillager.Options, error) {
+	return scanner.LoadConfig()
 }

--- a/internal/templates/table.tmpl
+++ b/internal/templates/table.tmpl
@@ -1,8 +1,0 @@
-# Pillager
-Results of your latest hunt from {{ now.Format "2006-01-02 15:04 MST" }}
-
-| File    |  Line    | Secret |
-| --------| ---------| -------- |
-{{ range . -}}
-    | {{ .File }} | {{ .StartLine }} | {{ quote .Secret }} |
-{{ end -}}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -14,9 +14,6 @@ var (
 
 	//go:embed markdown.tmpl
 	Markdown string
-
-	//go:embed table.tmpl
-	Table string
 )
 
 // DefaultTemplate is the base template used to format a Finding into the

--- a/pillager.go
+++ b/pillager.go
@@ -62,9 +62,6 @@ type Finding struct {
 
 	// Entropy is the shannon entropy of Value
 	Entropy float32
-
-	// Rule is the name of the rule that was matched
-	RuleID string
 }
 
 // Options holds configuration for scanners
@@ -74,24 +71,27 @@ type Options struct {
 	Workers   int       `toml:"workers"`
 	Verbose   bool      `toml:"verbose"`
 	Redact    bool      `toml:"redact"`
-	Reporter  string    `toml:"reporter"`
+	Format    string    `toml:"format"`
+	Dedup     bool      `toml:"dedup"`
+	Entropy   float64   `toml:"entropy"`
 	Rules     []Rule    `toml:"rules"`
 	Allowlist Allowlist `toml:"allowlist"`
 }
 
 // Rule represents a scanning rule
 type Rule struct {
-	ID          string   `toml:"id"`
-	Description string   `toml:"description"`
-	Path        string   `toml:"path"`
-	Regex       string   `toml:"regex"`
-	Keywords    []string `toml:"keywords"`
-	Tags        []string `toml:"tags"`
+	ID          string   `toml:"id" json:"id"`
+	Description string   `toml:"description" json:"description"`
+	Path        string   `toml:"path" json:"path"`
+	Regex       string   `toml:"regex" json:"regex"`
+	Keywords    []string `toml:"keywords" json:"keywords"`
+	Tags        []string `toml:"tags" json:"tags"`
 	Allowlist   Allowlist
 }
 
 // Allowlist represents paths and patterns to ignore
 type Allowlist struct {
-	Paths   []string `toml:"paths"`
-	Regexes []string `toml:"regexes"`
+	Paths     []string `toml:"paths"`
+	Regexes   []string `toml:"regexes"`
+	StopWords []string `toml:"stopwords"`
 }

--- a/pillager.toml
+++ b/pillager.toml
@@ -1,9 +1,7 @@
 # Basic configuration
 verbose = false 
-path = "."
-workers = 4
 redact = false 
-reporter = "json-pretty"
+format = "json-pretty"
 
 # Rules for secret detection
 [[rules]]
@@ -23,22 +21,3 @@ description = "GitHub Token"
 id = "github-token"
 regex = '''ghp_[0-9a-zA-Z]{36}'''
 tags = ["github", "token"]
-
-[[rules]]
-description = "Private Key"
-id = "private-key"
-regex = '''-----BEGIN (?:RSA|OPENSSH|DSA|EC|PGP) PRIVATE KEY( BLOCK)?-----'''
-tags = ["key", "private"]
-
-# Allowlist configuration
-[allowlist]
-paths = [
-    ".*/_test\\.go$",
-    ".*/testdata/.*",
-    ".*\\.md$",
-    ".*/vendor/.*"
-]
-regexes = [
-    "EXAMPLE_KEY",
-    "DUMMY_SECRET"
-] 

--- a/pkg/report/format.go
+++ b/pkg/report/format.go
@@ -1,8 +1,10 @@
 package report
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"io"
+	"strconv"
 
 	"github.com/brittonhayes/pillager"
 	"github.com/brittonhayes/pillager/internal/templates"
@@ -43,10 +45,45 @@ func (Markdown) Report(w io.Writer, findings []pillager.Finding) error {
 	return Render(w, templates.Markdown, findings)
 }
 
-type Table struct{}
+type CSV struct{}
 
-func (Table) Report(w io.Writer, findings []pillager.Finding) error {
-	return Render(w, templates.Table, findings)
+func (CSV) Report(w io.Writer, findings []pillager.Finding) error {
+	csvWriter := csv.NewWriter(w)
+	defer csvWriter.Flush()
+
+	// Write header
+	header := []string{
+		"Description",
+		"Secret",
+		"File",
+		"StartLine",
+		"EndLine",
+		"StartColumn",
+		"EndColumn",
+		"Match",
+	}
+	if err := csvWriter.Write(header); err != nil {
+		return err
+	}
+
+	// Write findings
+	for _, f := range findings {
+		record := []string{
+			f.Description,
+			f.Secret,
+			f.File,
+			strconv.Itoa(f.StartLine),
+			strconv.Itoa(f.EndLine),
+			strconv.Itoa(f.StartColumn),
+			strconv.Itoa(f.EndColumn),
+			f.Match,
+		}
+		if err := csvWriter.Write(record); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 type Wordlist struct{}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -29,12 +29,12 @@ func StringToReporter(s string) Reporter {
 		return JSONPretty{}
 	case "wordlist":
 		return Wordlist{}
-	case "table":
-		return Table{}
 	case "html":
 		return HTML{}
 	case "markdown":
 		return Markdown{}
+	case "csv":
+		return CSV{}
 	case "custom":
 		return Custom{}
 	default:

--- a/pkg/scanner/config.go
+++ b/pkg/scanner/config.go
@@ -2,8 +2,6 @@ package scanner
 
 import (
 	"fmt"
-	"path/filepath"
-	"runtime"
 
 	"github.com/BurntSushi/toml"
 	"github.com/brittonhayes/pillager"
@@ -12,25 +10,7 @@ import (
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
-// ConfigLoader handles loading configuration from files
-type ConfigLoader struct {
-	v *viper.Viper
-}
-
-// NewConfigLoader creates a new configuration loader
-func NewConfigLoader() *ConfigLoader {
-	v := viper.New()
-	v.SetDefault("verbose", false)
-	v.SetDefault("path", ".")
-	v.SetDefault("template", "")
-	v.SetDefault("workers", runtime.NumCPU())
-	v.SetDefault("redact", false)
-	v.SetDefault("reporter", "json")
-
-	return &ConfigLoader{v: v}
-}
-
-func convertDefaultConfig() (*pillager.Options, error) {
+func ConvertDefaultConfig() (*pillager.Options, error) {
 	var defaultConfig config.Config
 
 	if err := toml.Unmarshal([]byte(config.DefaultConfig), &defaultConfig); err != nil {
@@ -46,93 +26,39 @@ func convertDefaultConfig() (*pillager.Options, error) {
 }
 
 // LoadConfig attempts to load configuration from a file
-func (c *ConfigLoader) LoadConfig(configPath string) (*pillager.Options, error) {
-
+func LoadConfig() (*pillager.Options, error) {
 	// Rules and allowlist defaults
-	defaultConfig, err := convertDefaultConfig()
+	defaultConfig, err := ConvertDefaultConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert default rules")
 	}
 
-	c.v.SetDefault("rules", defaultConfig.Rules)
-	c.v.SetDefault("allowlist.paths", defaultConfig.Allowlist.Paths)
-	c.v.SetDefault("allowlist.regexes", defaultConfig.Allowlist.Regexes)
-
-	if configPath != "" {
-		// Use specified config file
-		ext := filepath.Ext(configPath)
-		if ext != ".toml" {
-			return nil, fmt.Errorf("config file must have an extension .toml")
-		}
-		c.v.SetConfigType(ext[1:])
-		c.v.SetConfigFile(configPath)
-
-		if err := c.v.ReadInConfig(); err != nil {
-			return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
-		}
-	} else {
-		// Search for config in default locations
-		c.v.SetConfigName("pillager")
-		c.v.AddConfigPath(".")
-		c.v.AddConfigPath("$HOME/.pillager")
-		c.v.AddConfigPath("$HOME/.config/pillager")
-
-		c.v.ReadInConfig()
-	}
+	viper.SetDefault("rules", defaultConfig.Rules)
+	viper.SetDefault("allowlist.paths", defaultConfig.Allowlist.Paths)
+	viper.SetDefault("allowlist.regexes", defaultConfig.Allowlist.Regexes)
 
 	// Create options from config
 	opts := &pillager.Options{
-		Path:     c.v.GetString("path"),
-		Workers:  c.v.GetInt("workers"),
-		Verbose:  c.v.GetBool("verbose"),
-		Template: c.v.GetString("template"),
-		Redact:   c.v.GetBool("redact"),
-		Reporter: c.v.GetString("reporter"),
+		Path:     viper.GetString("path"),
+		Workers:  viper.GetInt("workers"),
+		Verbose:  viper.GetBool("verbose"),
+		Template: viper.GetString("template"),
+		Redact:   viper.GetBool("redact"),
+		Format:   viper.GetString("format"),
+		Dedup:    viper.GetBool("dedupe"),
+		Entropy:  viper.GetFloat64("entropy"),
 		Allowlist: pillager.Allowlist{
-			Paths:   c.v.GetStringSlice("allowlist.paths"),
-			Regexes: c.v.GetStringSlice("allowlist.regexes"),
+			Paths:   viper.GetStringSlice("allowlist.paths"),
+			Regexes: viper.GetStringSlice("allowlist.regexes"),
 		},
 	}
 
 	// Unmarshal rules if they exist
 	var rules []pillager.Rule
-	if err := c.v.UnmarshalKey("rules", &rules); err != nil {
+	if err := viper.UnmarshalKey("rules", &rules); err != nil {
 		return nil, fmt.Errorf("failed to parse rules configuration: %w", err)
 	}
 	opts.Rules = rules
 
 	return opts, nil
-}
-
-// MergeWithFlags merges configuration with command line flags
-func (c *ConfigLoader) MergeWithFlags(opts *pillager.Options, flags *pillager.Options) {
-	if flags.Verbose {
-		opts.Verbose = flags.Verbose
-	}
-	if flags.Redact {
-		opts.Redact = flags.Redact
-	}
-	if flags.Workers > 0 {
-		opts.Workers = flags.Workers
-	}
-	if flags.Reporter != "" {
-		opts.Reporter = flags.Reporter
-	}
-	if flags.Template != "" {
-		opts.Template = flags.Template
-	}
-	if flags.Path != "" {
-		opts.Path = flags.Path
-	}
-	// Merge rules if provided
-	if len(flags.Rules) > 0 {
-		opts.Rules = flags.Rules
-	}
-	// Merge allowlist if provided
-	if len(flags.Allowlist.Paths) > 0 {
-		opts.Allowlist.Paths = flags.Allowlist.Paths
-	}
-	if len(flags.Allowlist.Regexes) > 0 {
-		opts.Allowlist.Regexes = flags.Allowlist.Regexes
-	}
 }

--- a/pkg/scanner/dedupe.go
+++ b/pkg/scanner/dedupe.go
@@ -1,0 +1,32 @@
+package scanner
+
+import (
+	"github.com/brittonhayes/pillager"
+)
+
+// DedupFindings removes duplicate findings based on the secret value.
+// It preserves the first occurrence of each unique secret.
+func DedupFindings(findings []pillager.Finding) []pillager.Finding {
+	if len(findings) <= 1 {
+		return findings
+	}
+
+	// Preallocate the map with the expected size to avoid resizing
+	seen := make(map[string]struct{}, len(findings))
+	// Reuse the input slice to avoid allocating new memory
+	// Keep track of where we're writing with a separate index
+	writeIndex := 0
+
+	for i, finding := range findings {
+		if _, exists := seen[finding.Secret]; !exists {
+			seen[finding.Secret] = struct{}{}
+			// Only copy elements if we need to (writeIndex != current index)
+			if writeIndex != i {
+				findings[writeIndex] = finding
+			}
+			writeIndex++
+		}
+	}
+
+	return findings[:writeIndex]
+}


### PR DESCRIPTION
# Changes

- adds support for deduplicating pillager output
- adds csv output format via `-f csv`
- adds minimum entropy option for higher signal findings (default 3.0)
- fixes configuration issues that were resulting in no results for some scans
- adds support for gitleaks stopwords
- simplifies default example pillager.toml in repository
- adds support for printing your settings via `--settings`